### PR TITLE
Extend example to show embedded Xtext editor for transitions.

### DIFF
--- a/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.design/META-INF/MANIFEST.MF
+++ b/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.design/META-INF/MANIFEST.MF
@@ -14,6 +14,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.resources;bundle-version="3.9.0",
  org.eclipse.jface.text;bundle-version="3.9.1",
  org.eclipse.ui.ide;bundle-version="3.10.1",
- org.eclipse.ui.workbench.texteditor;bundle-version="3.9.0"
+ org.eclipse.ui.workbench.texteditor;bundle-version="3.9.0",
+ org.eclipse.gmf.runtime.diagram.ui,
+ org.eclipse.gmf.runtime.notation.edit
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.design/description/fowlerdsl.odesign
+++ b/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.design/description/fowlerdsl.odesign
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<description:Group xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:tool="http://www.eclipse.org/sirius/diagram/description/tool/1.1.0" xmlns:tool_1="http://www.eclipse.org/sirius/description/tool/1.1.0" name="statemachine" version="8.1.0">
+<description:Group xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:tool="http://www.eclipse.org/sirius/diagram/description/tool/1.1.0" xmlns:tool_1="http://www.eclipse.org/sirius/description/tool/1.1.0" name="statemachine" version="10.0.0.201505222000">
   <ownedViewpoints name="Design" modelFileExtension="statemachine">
     <ownedRepresentations xsi:type="description_1:DiagramDescription" name="State Machine Diagram" domainClass="statemachine.Statemachine" enablePopupBars="true">
       <metamodel href="http://www.eclipse.org/xtext/example/fowlerdsl/Statemachine#/"/>
       <defaultLayer name="Default">
-        <edgeMappings name="Transitions" label="Transitions" semanticCandidatesExpression="feature:eAllContents" doubleClickDescription="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@toolSections.0/@ownedTools[name='NavigateToXtextEditor']" sourceMapping="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@containerMappings[name='State']" targetMapping="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@containerMappings[name='State']" targetFinderExpression="feature:state" sourceFinderExpression="feature:eContainer" domainClass="statemachine.Transition" useDomainElement="true">
-          <style sizeComputationExpression="1">
+        <edgeMappings name="Transitions" label="Transitions" semanticCandidatesExpression="feature:eAllContents" doubleClickDescription="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@toolSections.0/@ownedTools[name='OpenEmbeddedEditor']" sourceMapping="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@containerMappings[name='State']" targetMapping="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@containerMappings[name='State']" targetFinderExpression="feature:state" sourceFinderExpression="feature:eContainer" domainClass="statemachine.Transition" useDomainElement="true">
+          <style>
             <strokeColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
             <centerLabelStyleDescription showIcon="false" labelExpression="['[' + event.name + ']'/]">
               <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
             </centerLabelStyleDescription>
           </style>
           <conditionnalStyles predicateExpression="[event.oclIsUndefined()/]">
-            <style sizeComputationExpression="1">
+            <style>
               <strokeColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='red']"/>
               <centerLabelStyleDescription showIcon="false" labelExpression="[??] no event !">
                 <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='red']"/>
@@ -28,15 +28,17 @@
               <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
             </style>
           </subNodeMappings>
-          <style xsi:type="style:FlatContainerStyleDescription" arcWidth="6" arcHeight="6" labelFormat="bold" showIcon="false" iconPath="/org.eclipse.sirius.example.fowlerdsl.design/icons/State.gif" roundedCorner="true" widthComputationExpression="8" heightComputationExpression="6" backgroundStyle="Liquid">
+          <style xsi:type="style:FlatContainerStyleDescription" arcWidth="6" arcHeight="6" showIcon="false" iconPath="/org.eclipse.sirius.example.fowlerdsl.design/icons/State.gif" roundedCorner="true" widthComputationExpression="8" heightComputationExpression="6" backgroundStyle="Liquid">
             <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_blue']"/>
+            <labelFormat>bold</labelFormat>
             <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_gray']"/>
             <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
             <foregroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='light_gray']"/>
           </style>
           <conditionnalStyles predicateExpression="[transitions->size() = 0 and eInverse()->filter(Transition)->size() = 0/]">
-            <style xsi:type="style:FlatContainerStyleDescription" arcWidth="6" arcHeight="6" labelFormat="bold" showIcon="false" iconPath="/org.eclipse.sirius.example.fowlerdsl.design/icons/State.gif" roundedCorner="true" widthComputationExpression="8" heightComputationExpression="6" backgroundStyle="Liquid">
+            <style xsi:type="style:FlatContainerStyleDescription" arcWidth="6" arcHeight="6" showIcon="false" iconPath="/org.eclipse.sirius.example.fowlerdsl.design/icons/State.gif" roundedCorner="true" widthComputationExpression="8" heightComputationExpression="6" backgroundStyle="Liquid">
               <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='light_gray']"/>
+              <labelFormat>bold</labelFormat>
               <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
               <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
               <foregroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='light_gray']"/>
@@ -45,13 +47,14 @@
         </containerMappings>
         <containerMappings name="CommandsContainer" semanticCandidatesExpression="var:self" domainClass="statemachine.Statemachine" childrenPresentation="List">
           <subNodeMappings name="Command" semanticCandidatesExpression="feature:commands" doubleClickDescription="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@toolSections.0/@ownedTools[name='NavigateToXtextEditor']" domainClass="statemachine.Command">
-            <style xsi:type="style:BundledImageDescription" labelFormat="italic" labelExpression="[self.name + ':' + self.code/]" iconPath="/org.eclipse.sirius.example.fowlerdsl.design/icons/Operation.gif" labelAlignment="LEFT" resizeKind="NSEW">
+            <style xsi:type="style:BundledImageDescription" labelExpression="[self.name + ':' + self.code/]" iconPath="/org.eclipse.sirius.example.fowlerdsl.design/icons/Operation.gif" labelAlignment="LEFT" resizeKind="NSEW">
               <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+              <labelFormat>italic</labelFormat>
               <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
               <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
             </style>
           </subNodeMappings>
-          <style xsi:type="style:FlatContainerStyleDescription" showIcon="false" labelExpression="Available Commands" backgroundStyle="Liquid">
+          <style xsi:type="style:FlatContainerStyleDescription" arcWidth="1" arcHeight="1" showIcon="false" labelExpression="Available Commands" backgroundStyle="Liquid">
             <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
             <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
             <backgroundColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
@@ -138,7 +141,7 @@
               </firstModelOperations>
             </initialOperation>
           </ownedTools>
-          <ownedTools xsi:type="tool:DoubleClickDescription" name="NavigateToXtextEditor" mappings="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@edgeMappings[name='Transitions'] //@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@additionalLayers[name='Events']/@edgeMappings[name='TransitionToEvent'] //@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@containerMappings[name='State']/@subNodeMappings[name='CommandRef'] //@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@containerMappings[name='CommandsContainer']/@subNodeMappings[name='Command'] //@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@additionalLayers[name='Events']/@nodeMappings[name='Event']">
+          <ownedTools xsi:type="tool:DoubleClickDescription" name="NavigateToXtextEditor" mappings="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@additionalLayers[name='Events']/@edgeMappings[name='TransitionToEvent'] //@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@containerMappings[name='State']/@subNodeMappings[name='CommandRef'] //@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@containerMappings[name='CommandsContainer']/@subNodeMappings[name='Command']">
             <element name="element"/>
             <elementView name="elementView"/>
             <initialOperation>
@@ -147,7 +150,7 @@
               </firstModelOperations>
             </initialOperation>
           </ownedTools>
-          <ownedTools xsi:type="tool:DoubleClickDescription" name="OpenEmbeddedEditor" mappings="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@containerMappings[name='State']">
+          <ownedTools xsi:type="tool:DoubleClickDescription" name="OpenEmbeddedEditor" mappings="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@containerMappings[name='State'] //@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@edgeMappings[name='Transitions']">
             <element name="element"/>
             <elementView name="elementView"/>
             <initialOperation>
@@ -193,15 +196,16 @@
         </toolSections>
       </defaultLayer>
       <additionalLayers name="Events">
-        <nodeMappings name="Event" labelDirectEdit="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@toolSections.0/@ownedTools[name='Edit%20name']" semanticCandidatesExpression="feature:events" doubleClickDescription="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@toolSections.0/@ownedTools[name='NavigateToXtextEditor']" domainClass="statemachine.Event">
-          <style xsi:type="style:BundledImageDescription" labelFormat="bold" iconPath="/org.eclipse.sirius.example.fowlerdsl.design/icons/SignalEvent.gif" resizeKind="NSEW" shape="triangle">
+        <nodeMappings name="Event" labelDirectEdit="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@toolSections.0/@ownedTools[name='Edit%20name']" semanticCandidatesExpression="feature:events" domainClass="statemachine.Event">
+          <style xsi:type="style:BundledImageDescription" iconPath="/org.eclipse.sirius.example.fowlerdsl.design/icons/SignalEvent.gif" resizeKind="NSEW" shape="triangle">
             <borderColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+            <labelFormat>bold</labelFormat>
             <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
             <color xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='light_green']"/>
           </style>
         </nodeMappings>
         <edgeMappings name="TransitionToEvent" doubleClickDescription="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@toolSections.0/@ownedTools[name='NavigateToXtextEditor']" sourceMapping="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@defaultLayer/@edgeMappings[name='Transitions']" targetMapping="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='State%20Machine%20Diagram']/@additionalLayers[name='Events']/@nodeMappings[name='Event']" targetFinderExpression="feature:event">
-          <style lineStyle="dash" sourceArrow="InputArrow" targetArrow="NoDecoration" sizeComputationExpression="1">
+          <style lineStyle="dash" sourceArrow="InputArrow" targetArrow="NoDecoration">
             <strokeColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='gray']"/>
             <centerLabelStyleDescription>
               <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>

--- a/xtext-support-parent/plugins/org.obeonetwork.dsl.viewpoint.xtext.support/src/org/obeonetwork/dsl/viewpoint/xtext/support/action/OpenXtextEmbeddedEditor.java
+++ b/xtext-support-parent/plugins/org.obeonetwork.dsl.viewpoint.xtext.support/src/org/obeonetwork/dsl/viewpoint/xtext/support/action/OpenXtextEmbeddedEditor.java
@@ -16,9 +16,11 @@ import java.util.Map;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.gef.EditPart;
+import org.eclipse.gmf.runtime.diagram.ui.editparts.ConnectionEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.DiagramEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.editparts.IGraphicalEditPart;
 import org.eclipse.gmf.runtime.diagram.ui.parts.DiagramEditor;
+import org.eclipse.gmf.runtime.notation.Edge;
 import org.eclipse.sirius.tools.api.ui.IExternalJavaAction;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbench;
@@ -45,10 +47,37 @@ public abstract class OpenXtextEmbeddedEditor implements IExternalJavaAction {
 				openEmbeddedEditor((IGraphicalEditPart) editPart);
 				break;
 			}
+			else {
+				ConnectionEditPart cep = findConnectionEditPart(diagramEditPart, o);
+				if (cep != null) {
+					openEmbeddedEditor(cep);
+					break;
+				}
+			}
 		}
 
 	}
 	
+    /** Finds an connection editpart given a starting editpart and an EObject */
+	private ConnectionEditPart findConnectionEditPart(DiagramEditPart diagramEditPart, EObject theElement) {
+		for (Object obj : diagramEditPart.getChildren()) {
+			if (obj instanceof IGraphicalEditPart) {
+				IGraphicalEditPart ep = (IGraphicalEditPart) obj;
+				// Only consider source connections
+				for (Object o : ep.getSourceConnections())
+				{
+					if (o instanceof ConnectionEditPart) {
+						ConnectionEditPart cep = (ConnectionEditPart) o;
+						if (((Edge)cep.getModel()).getElement().equals(theElement)) {
+							return cep;
+						}
+					}
+				}
+			}
+		}
+		return null;
+	}
+
 	protected  void openEmbeddedEditor(IGraphicalEditPart graphicalEditPart) {
 			XtextEmbeddedEditor embeddedEditor = new XtextEmbeddedEditor(graphicalEditPart, getInjector());
 			embeddedEditor.showEditor();	


### PR DESCRIPTION
Hi Obeo,

The example only worked for nodes on the diagram. So I spend some time to extendthe example to enable showing the editor for edges as well. To do this, I had to find the ConnectionEditPart given the semantic element passed from the Sirius diagram. I can imagine the way I did it can be more efficient, so feedback is desired.

Kind regards,
Niels Brouwers.