### PR TITLE
Deactivate key handlers when closing editor

### DIFF
--- a/xtext-support-parent/plugins/org.obeonetwork.dsl.viewpoint.xtext.support/src/org/obeonetwork/dsl/viewpoint/xtext/support/XtextEmbeddedEditor.java
+++ b/xtext-support-parent/plugins/org.obeonetwork.dsl.viewpoint.xtext.support/src/org/obeonetwork/dsl/viewpoint/xtext/support/XtextEmbeddedEditor.java
@@ -170,6 +170,7 @@ public class XtextEmbeddedEditor {
 			}
 			// xtextEditor.dispose();
 			if (xtextEditorComposite != null) {
+				this.xtextEditorComposite.setVisible(false);
 				this.xtextEditorComposite.dispose();
 				xtextEditorComposite = null;
 			}


### PR DESCRIPTION
If the xtextEditorComposite is not hidden before being disposed its
text navigation handlers are not deactivated, interfering with normal
Eclipse behaviour.

Furthermore, if another embedded editor is subsequently spawned, key
bindings conflict do happen:

```
!MESSAGE Conflicting handlers for org.eclipse.ui.edit.text.select.textStart: {ActionHandler(org.eclipse.ui.texteditor.TextNavigationAction@2329f146)} vs {ActionHandler(org.eclipse.ui.texteditor.TextNavigationAction@4648449f)}
```