### PR TITLE
Custom widget to display Xtext formatted text in Sirius PVDs

### DIFF
--- a/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/.classpath
+++ b/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/.project
+++ b/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.sirius.example.fowlerdsl.xtextwidget</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/.settings/org.eclipse.jdt.core.prefs
+++ b/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.8

--- a/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/META-INF/MANIFEST.MF
+++ b/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/META-INF/MANIFEST.MF
@@ -1,0 +1,18 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Xtext Widget for Sirius Properties Views
+Bundle-SymbolicName: org.eclipse.sirius.example.fowlerdsl.xtextwidget;singleton:=true
+Bundle-Version: 1.0.0.qualifier
+Bundle-Vendor: Obeo
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Require-Bundle: org.eclipse.eef.core,
+ org.eclipse.eef,
+ org.eclipse.sirius.common.interpreter,
+ org.eclipse.equinox.registry,
+ org.eclipse.eef.ide.ui,
+ org.eclipse.swt,
+ org.eclipse.emf.mwe.core,
+ org.eclipse.eef.common.ui,
+ com.google.inject,
+ org.eclipse.xtext.example.fowlerdsl.ui,
+ org.eclipse.xtext.ui

--- a/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/build.properties
+++ b/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml

--- a/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/plugin.xml
+++ b/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/plugin.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.eclipse.eef.ide.ui.eefLifecycleManagerProvider">
+      <descriptor
+            class="org.eclipse.sirius.example.fowlerdsl.xtextwidget.XtextPartialViewerLifecycleManagerProvider"
+            description="Xtext partial viewer"
+            id="org.eclipse.sirius.example.fowlerdsl.xtextwidget.XtextPartialViewer"
+            label="Xtext Partial Viewer">
+      </descriptor>
+   </extension>
+
+</plugin>

--- a/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/src/org/eclipse/sirius/example/fowlerdsl/xtextwidget/XtextPartialViewerController.java
+++ b/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/src/org/eclipse/sirius/example/fowlerdsl/xtextwidget/XtextPartialViewerController.java
@@ -1,0 +1,37 @@
+package org.eclipse.sirius.example.fowlerdsl.xtextwidget;
+
+import org.eclipse.eef.EEFCustomWidgetDescription;
+import org.eclipse.eef.core.api.EditingContextAdapter;
+import org.eclipse.eef.core.api.controllers.AbstractEEFCustomWidgetController;
+import org.eclipse.eef.core.api.controllers.IConsumer;
+import org.eclipse.sirius.common.interpreter.api.IInterpreter;
+import org.eclipse.sirius.common.interpreter.api.IVariableManager;
+
+public class XtextPartialViewerController extends AbstractEEFCustomWidgetController {
+
+	private IConsumer<Object> newValueConsumer;
+
+	public XtextPartialViewerController(EEFCustomWidgetDescription description, IVariableManager variableManager, IInterpreter interpreter,
+			EditingContextAdapter contextAdapter) {
+		super(description, variableManager, interpreter, contextAdapter);
+	}
+
+	@Override
+	protected EEFCustomWidgetDescription getDescription() {
+		return this.description;
+	}
+
+	@Override
+	public void refresh() {
+		super.refresh();
+		this.newEval().call("var:self", this.newValueConsumer);
+	}
+
+	public void onNewValue(IConsumer<Object> consumer) {
+		this.newValueConsumer = consumer;
+	}
+
+	public void removeValueConsumer() {
+		this.newValueConsumer = null;
+	}
+}

--- a/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/src/org/eclipse/sirius/example/fowlerdsl/xtextwidget/XtextPartialViewerLifecycleManager.java
+++ b/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/src/org/eclipse/sirius/example/fowlerdsl/xtextwidget/XtextPartialViewerLifecycleManager.java
@@ -1,0 +1,98 @@
+package org.eclipse.sirius.example.fowlerdsl.xtextwidget;
+
+import org.eclipse.eef.EEFCustomWidgetDescription;
+import org.eclipse.eef.EEFWidgetDescription;
+import org.eclipse.eef.common.ui.api.IEEFFormContainer;
+import org.eclipse.eef.core.api.EditingContextAdapter;
+import org.eclipse.eef.core.api.controllers.IConsumer;
+import org.eclipse.eef.core.api.controllers.IEEFWidgetController;
+import org.eclipse.eef.ide.ui.api.widgets.AbstractEEFWidgetLifecycleManager;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.sirius.common.interpreter.api.IInterpreter;
+import org.eclipse.sirius.common.interpreter.api.IVariableManager;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.xtext.example.fowlerdsl.ui.internal.StatemachineActivator;
+
+import com.google.inject.Injector;
+
+public class XtextPartialViewerLifecycleManager extends AbstractEEFWidgetLifecycleManager {
+
+	private EEFCustomWidgetDescription description;
+	
+	private XtextPartialViewerWidget xtextPartialEditorWidget;
+	
+	private XtextPartialViewerController controller;
+	
+	private IConsumer<Object> newValueConsumer;
+	
+	public XtextPartialViewerLifecycleManager(
+			EEFCustomWidgetDescription controlDescription,
+			IVariableManager variableManager, 
+			IInterpreter interpreter, 
+			EditingContextAdapter contextAdapter) {
+		super(variableManager, interpreter, contextAdapter);
+		this.description = controlDescription;
+	}
+
+	@Override
+	protected void createMainControl(Composite parent, IEEFFormContainer formContainer) {
+		Injector injector = StatemachineActivator.getInstance().getInjector(StatemachineActivator.ORG_ECLIPSE_XTEXT_EXAMPLE_FOWLERDSL_STATEMACHINE);
+		xtextPartialEditorWidget = new XtextPartialViewerWidget(parent, injector, SWT.BORDER | SWT.H_SCROLL);
+		Control control = xtextPartialEditorWidget.getControl();
+		GridData data = new GridData(SWT.FILL, SWT.FILL, false, true);
+		data.widthHint = 750;
+		control.setLayoutData(data);
+		
+		this.controller = new XtextPartialViewerController(description, variableManager, interpreter, contextAdapter);
+	}
+
+	@Override
+	public void aboutToBeShown() {
+		super.aboutToBeShown();
+		
+		this.newValueConsumer = (newValue) -> this.xtextPartialEditorWidget.update((EObject)newValue);
+		this.controller.onNewValue(this.newValueConsumer);
+	}
+	
+	@Override
+	public void refresh() {
+		super.refresh();
+		this.controller.refresh();
+	}
+
+	@Override
+	public void aboutToBeHidden() {
+		super.aboutToBeHidden();
+		this.controller.removeValueConsumer();
+		this.newValueConsumer = null;
+	}
+
+	@Override
+	protected IEEFWidgetController getController() {
+		return this.controller;
+	}
+
+	@Override
+	protected EEFWidgetDescription getWidgetDescription() {
+		return this.description;
+	}
+
+	@Override
+	protected Control getValidationControl() {
+		return this.xtextPartialEditorWidget.getControl();
+	}
+
+	@Override
+	public void dispose() {
+		super.dispose();
+	}
+
+	@Override
+	protected void setEnabled(boolean enabled) {
+		// Not handled.
+	}
+
+}

--- a/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/src/org/eclipse/sirius/example/fowlerdsl/xtextwidget/XtextPartialViewerLifecycleManagerProvider.java
+++ b/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/src/org/eclipse/sirius/example/fowlerdsl/xtextwidget/XtextPartialViewerLifecycleManagerProvider.java
@@ -1,0 +1,34 @@
+package org.eclipse.sirius.example.fowlerdsl.xtextwidget;
+
+import org.eclipse.eef.EEFControlDescription;
+import org.eclipse.eef.EEFCustomWidgetDescription;
+import org.eclipse.eef.core.api.EditingContextAdapter;
+import org.eclipse.eef.ide.ui.api.widgets.IEEFLifecycleManager;
+import org.eclipse.eef.ide.ui.api.widgets.IEEFLifecycleManagerProvider;
+import org.eclipse.sirius.common.interpreter.api.IInterpreter;
+import org.eclipse.sirius.common.interpreter.api.IVariableManager;
+
+public class XtextPartialViewerLifecycleManagerProvider implements IEEFLifecycleManagerProvider {
+
+	private static final String SUPPORTED_ID = "org.eclipse.sirius.example.fowlerdsl.xtextwidget.XtextPartialViewer";
+	
+	@Override
+	public boolean canHandle(EEFControlDescription controlDescription) {
+		return SUPPORTED_ID.equals(controlDescription.getIdentifier()) && 
+				controlDescription instanceof EEFCustomWidgetDescription;
+	}
+
+	@Override
+	public IEEFLifecycleManager getLifecycleManager(
+			EEFControlDescription controlDescription, 
+			IVariableManager variableManager,
+			IInterpreter interpreter, 
+			EditingContextAdapter contextAdapter) {
+		if (controlDescription instanceof EEFCustomWidgetDescription) {
+			return new XtextPartialViewerLifecycleManager((EEFCustomWidgetDescription) controlDescription, variableManager, interpreter, contextAdapter);
+		}
+		throw new IllegalArgumentException();
+	}
+	
+
+}

--- a/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/src/org/eclipse/sirius/example/fowlerdsl/xtextwidget/XtextPartialViewerWidget.java
+++ b/xtext-support-parent/examples/org.eclipse.sirius.example.fowlerdsl.xtextwidget/src/org/eclipse/sirius/example/fowlerdsl/xtextwidget/XtextPartialViewerWidget.java
@@ -1,0 +1,98 @@
+package org.eclipse.sirius.example.fowlerdsl.xtextwidget;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentPartitioner;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.xtext.Constants;
+import org.eclipse.xtext.nodemodel.ICompositeNode;
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.ui.editor.XtextSourceViewer;
+import org.eclipse.xtext.ui.editor.XtextSourceViewerConfiguration;
+import org.eclipse.xtext.ui.editor.model.XtextDocument;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import com.google.inject.name.Named;
+
+public class XtextPartialViewerWidget {
+
+	private int style;
+
+	private XtextSourceViewer sourceViewer;
+	
+	private XtextDocument document;
+	
+	@Inject
+	@Named(Constants.FILE_EXTENSIONS)
+	private String fileExtension;
+
+	@Inject
+	private XtextSourceViewer.Factory sourceViewerFactory;
+
+	@Inject
+	private Provider<XtextSourceViewerConfiguration> sourceViewerConfigurationProvider;
+
+	@Inject
+	private Provider<XtextDocument> documentProvider;
+
+	@Inject 
+	private Provider<IDocumentPartitioner> documentPartitioner;
+	
+	public XtextPartialViewerWidget(Composite parentComposite, Injector xtextInjector, int style) {
+		this.style = style;
+		
+		xtextInjector.injectMembers(this);
+
+		createEditor(parentComposite);
+	}
+	
+	public XtextPartialViewerWidget(Composite control, Injector injector) {
+		this(control, injector, SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
+	}
+
+	private void createEditor(Composite parent) {
+		sourceViewer = sourceViewerFactory.createSourceViewer(parent, null, null, true, style);
+		sourceViewer.setEditable(false);
+		
+		XtextSourceViewerConfiguration viewerConfiguration = sourceViewerConfigurationProvider.get();
+		sourceViewer.configure(viewerConfiguration);	
+		
+		document = documentProvider.get();
+		
+		IDocumentPartitioner partitioner = documentPartitioner.get(); 
+		partitioner.connect(document); 
+		document.setDocumentPartitioner(partitioner);
+		
+		document.set("");
+		sourceViewer.setDocument(document);
+		
+	}
+	
+	public Control getControl() {
+		return sourceViewer.getControl();
+	}
+	
+	public void update(EObject semanticElement) {
+		
+		if (semanticElement != null) {
+			ICompositeNode elementNode = NodeModelUtils.findActualNodeFor(semanticElement);
+			update(elementNode.getText().trim());
+		}
+		
+	}
+	
+	public void update(String text) {
+		IDocument document = sourceViewer.getDocument();
+		
+		sourceViewer.setRedraw(false);
+		document.set(text);
+		sourceViewer.setVisibleRegion(0, text.length());
+		sourceViewer.setSelectedRange(0, 0);
+		sourceViewer.setRedraw(true);
+	}
+	
+}


### PR DESCRIPTION
This plugin contributes a Custom Widget to be used in a Properties View Descriptor.
The id of the widget is "org.eclipse.sirius.example.fowlerdsl.xtextwidget.XtextPartialViewer"
The contextual element (self) is taken as the only input (no need to define customised expressions).
The widget displays the serialized form of the object as it is in the defining text file.